### PR TITLE
Fix JumbleRangeTable() to jumble query with relation name. #13

### DIFF
--- a/sql_firewall.c
+++ b/sql_firewall.c
@@ -85,6 +85,8 @@
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
+#include "utils/rel.h"
+#include "utils/relcache.h"
 
 
 PG_MODULE_MAGIC;
@@ -1227,6 +1229,8 @@ pgss_store(const char *query, uint32 queryId,
 	int			query_len;
 
 	Assert(query != NULL);
+
+	elog(DEBUG1, "pgss_store: query=\"%s\" queryid=%u", query, queryId);
 
 	/* Safety check... */
 	if (!pgss || !pgss_hash)
@@ -2753,6 +2757,7 @@ static void
 JumbleRangeTable(pgssJumbleState *jstate, List *rtable)
 {
 	ListCell   *lc;
+	Relation rel;
 
 	foreach(lc, rtable)
 	{
@@ -2763,7 +2768,9 @@ JumbleRangeTable(pgssJumbleState *jstate, List *rtable)
 		switch (rte->rtekind)
 		{
 			case RTE_RELATION:
-				APP_JUMB(rte->relid);
+				rel = RelationIdGetRelation(rte->relid);
+				APP_JUMB_STRING(RelationGetRelationName(rel));
+				RelationClose(rel);
 				break;
 			case RTE_SUBQUERY:
 				JumbleQuery(jstate, rte->subquery);


### PR DESCRIPTION
Previously, JumbleRangeTable() used relation oid on query jumbling,
and it resulted different queryid when relid gets changed.

Now, JumbleRangeTable() uses relation name instead of relid
to calculate queryid, so queryid could be the same when table gets
dropped and created with the same name.
